### PR TITLE
Hide map type controls on smaller screens

### DIFF
--- a/js/maptools.js
+++ b/js/maptools.js
@@ -21,6 +21,12 @@ var maptools = {
                 mapTypeIds: [ 'roadmap', 'terrain', 'satellite', 'hybrid', 'silver', 'dark' ]
             }
         });
+
+        var width = window.innerWidth;
+        if (width < 768) {
+            maptools.map.mapTypeControlOptions = { mapTypeIds: [] };
+        }
+
         maptypes.init();
         maptools.map.mapTypes.set('silver', maptypes.silver);
         maptools.map.mapTypes.set('dark', maptypes.dark);


### PR DESCRIPTION
The map type controls (Map, Satellite, Silver, Dark) make the map harder to use on smaller screens like mobiles when the map is viewed in an iframe. This change removes those controls for smaller screens. This includes removing Map (roadmap) as that's the default so there is no need to click on it. 

This works when the map is viewed via an iframe, e.g. from the Help is Available site. It does not make any difference when the map is viewed as a full page map, but the controls don't currently get in the way when the full page map is viewed on a mobile.